### PR TITLE
v2: トークンのメタデータを設定する

### DIFF
--- a/contracts/PochiBukuro.sol
+++ b/contracts/PochiBukuro.sol
@@ -22,6 +22,33 @@ contract PochiBukuro is ERC721, Ownable {
     programmer = _programmer;
   }
 
+  function tokenURI(uint256 _tokenId) public view override returns (string memory) {
+    require(_exists(_tokenId), "Non-existent Token ID");
+
+    uint8 pattern = (_tokenId % 20) == 0 ? 9 : uint8(_tokenId % 4);
+
+    return string(
+      abi.encodePacked(
+        'data:application/json;base64,',
+        Base64.encode(
+          bytes(
+            abi.encodePacked(
+              '{"name":"', tokenName(_tokenId),
+                '","description":"Otoshidama in Pochi Bukuro',
+                '","attributes":[{"trait_type":"Pattern","value":"', pattern.toString(), '"}',
+                '],"image":"https://june29.github.io/pochibukuro/', pattern.toString(), '.png',
+              '"}'
+            )
+          )
+        )
+      )
+    );
+  }
+
+  function tokenName(uint256 _tokenId) internal pure override returns(string memory) {
+    return string(abi.encodePacked("Pochi Bukuro #", _tokenId.toString()));
+  }
+
   function otoshidama(address _destination) payable external {
     require(msg.value >= _FEE * 4, "More ether required");
 

--- a/contracts/PochiBukuro.sol
+++ b/contracts/PochiBukuro.sol
@@ -46,7 +46,7 @@ contract PochiBukuro is ERC721, Ownable {
     );
   }
 
-  function tokenName(uint256 _tokenId) internal pure override returns(string memory) {
+  function tokenName(uint256 _tokenId) internal pure returns(string memory) {
     return string(abi.encodePacked("Pochi Bukuro #", _tokenId.toString()));
   }
 

--- a/contracts/PochiBukuro.sol
+++ b/contracts/PochiBukuro.sol
@@ -9,7 +9,6 @@ import "@openzeppelin/contracts/utils/Counters.sol";
 contract PochiBukuro is ERC721, Ownable {
   using Counters for Counters.Counter;
 
-  string baseURI;
   address immutable public designer;
   address immutable public programmer;
   uint256 private constant _FEE = 0.0005 ether;
@@ -21,14 +20,6 @@ contract PochiBukuro is ERC721, Ownable {
   ) ERC721("Pochi Bukuro", "PB") {
     designer = _designer;
     programmer = _programmer;
-  }
-
-  function _baseURI() internal view virtual override returns (string memory) {
-    return baseURI;
-  }
-
-  function setBaseURI(string memory _newBaseURI) external onlyOwner {
-    baseURI = _newBaseURI;
   }
 
   function otoshidama(address _destination) payable external {

--- a/contracts/PochiBukuro.sol
+++ b/contracts/PochiBukuro.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.17;
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/Counters.sol";
+import "@openzeppelin/contracts/utils/Base64.sol";
 
 contract PochiBukuro is ERC721, Ownable {
   using Counters for Counters.Counter;

--- a/contracts/PochiBukuro.sol
+++ b/contracts/PochiBukuro.sol
@@ -4,8 +4,9 @@ pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
-import "@openzeppelin/contracts/utils/Counters.sol";
 import "@openzeppelin/contracts/utils/Base64.sol";
+import "@openzeppelin/contracts/utils/Counters.sol";
+import "@openzeppelin/contracts/utils/Strings.sol";
 
 contract PochiBukuro is ERC721, Ownable {
   using Counters for Counters.Counter;
@@ -36,8 +37,8 @@ contract PochiBukuro is ERC721, Ownable {
             abi.encodePacked(
               '{"name":"', tokenName(_tokenId),
                 '","description":"Otoshidama in Pochi Bukuro',
-                '","attributes":[{"trait_type":"Pattern","value":"', pattern.toString(), '"}',
-                '],"image":"https://june29.github.io/pochibukuro/', pattern.toString(), '.png',
+                '","attributes":[{"trait_type":"Pattern","value":"', Strings.toString(pattern), '"}',
+                '],"image":"https://june29.github.io/pochibukuro/', Strings.toString(pattern), '.png',
               '"}'
             )
           )
@@ -47,7 +48,7 @@ contract PochiBukuro is ERC721, Ownable {
   }
 
   function tokenName(uint256 _tokenId) internal pure returns(string memory) {
-    return string(abi.encodePacked("Pochi Bukuro #", _tokenId.toString()));
+    return string(abi.encodePacked("Pochi Bukuro #", Strings.toString(_tokenId)));
   }
 
   function otoshidama(address _destination) payable external {


### PR DESCRIPTION
https://github.com/june29/pochibukuro/pull/1 の実装を v1 として、ETH を送ったり受け取ったりのロジックを実装した。

この Pull Request は v2 として、Mint されるトークンのメタデータの設定を行う。扱う想定のデータは下記のようなもの。

- トークンの名前
- トークンの概要文
- トークンの画像
- トークンの Attributes
  - https://docs.opensea.io/docs/metadata-standards